### PR TITLE
emulate DOTALL flag in CLJS

### DIFF
--- a/src/ont_app/vocabulary/lstr.cljc
+++ b/src/ont_app/vocabulary/lstr.cljc
@@ -68,7 +68,7 @@
 
 (def langstring-re  #?(:clj #"(?s)^(.*)@([-a-zA-Z]+)"
                        ;; (?s) Dot matches all (including newline)
-                       :cljs #"^(.*)@([-a-zA-Z]+)"
+                       :cljs #"^((?:.|\s)*)@([-a-zA-Z]+)"
                        ;; This language feature is only supported for ECMASCRIPT_2018 mode or better: RegExp flag 's'
                        ))
     


### PR DESCRIPTION
Follow-up to https://github.com/ont-app/vocabulary/pull/14 that fixes the CLJS regex too, emulating DOTALL using a non-capturing group of `.` or `\s`.