### PR TITLE
Hack to escape quotes in strings when printing 

### DIFF
--- a/src/ont_app/vocabulary/lstr.cljc
+++ b/src/ont_app/vocabulary/lstr.cljc
@@ -30,8 +30,8 @@
 ;; for clj...
 #?(:clj
    (defmethod print-method LangStr
-     [literal ^java.io.Writer w]
-     (.write w (str "#voc/lstr \"" literal "@" (.lang literal) "\""))))
+     [^LangStr literal ^java.io.Writer w]
+     (.write w (pr-str (tagged-literal 'voc/lstr  (str literal "@" (.lang literal)))))))
 
 #?(:clj
    (defmethod print-dup LangStr [o ^java.io.Writer w]


### PR DESCRIPTION
Sometimes the strings have double quotes in them and they need to be escaped in order to be readable.

I just use clojure.core/tagged-literal to write an escaped string when printing LangStr. 