### PR TITLE
Fix Boolean type to use lowercase 'boolean'

### DIFF
--- a/src/ont_app/vocabulary/dstr.cljc
+++ b/src/ont_app/vocabulary/dstr.cljc
@@ -146,7 +146,7 @@
   "
   (atom {(type 0) "xsd:long"
          (type 0.0) "xsd:double"
-         (type true) "xsd:Boolean"
+         (type true) "xsd:boolean"
          (type #inst "2000") "xsd:dateTime"
          (type "") "xsd:string"
          (type (short 0)) "xsd:short"


### PR DESCRIPTION
I believe this was a typo during implementation.